### PR TITLE
Fix memory leak

### DIFF
--- a/flextyper/src/finder.cpp
+++ b/flextyper/src/finder.cpp
@@ -174,8 +174,6 @@ void Finder::sequentialSearch(ft::FTMap &ftMap,
     ftMap.addIndexResults(indexResults);
     LogClass::Log  << "(I) number of indexes processed " << indexResults.size() << std::endl;
     benchmark.now("sequentialSearch DONE ");
-
-    indexResults.clear();
     delete fmIndex;
 }
 

--- a/flextyper/src/finder.cpp
+++ b/flextyper/src/finder.cpp
@@ -133,6 +133,7 @@ void Finder::parallelSearch(FTMap &ftMap, const fs::path &indexPath,
     ftMap.addIndexResults(indexResults);
     LogClass::Log  << "(I) number of indexes processed " << indexResults.size() << std::endl;
     benchmark.now("parallelSearch DONE ");
+    delete fmIndex;
 }
 
 //======================================================================
@@ -175,6 +176,7 @@ void Finder::sequentialSearch(ft::FTMap &ftMap,
     benchmark.now("sequentialSearch DONE ");
 
     indexResults.clear();
+    delete fmIndex;
 }
 
 


### PR DESCRIPTION
Remove fmindex from memory once search is complete. 